### PR TITLE
Fix/refactor load method from the TS plugin

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -13,29 +13,34 @@ export interface Account {
   username: string;
 
   /**
+   * The password associated with the account.
+   */
+  password?: string;
+
+  /**
    * The provider of the account, if applicable.
    */
-  provider?: AccountProvider;
+  accountType: AccountType;
 
   /**
    * Indicates whether the account linkage has been verified.
    */
-  verified?: boolean;
+  isVerified?: boolean;
 }
 
 /**
  * Enumeration of possible account providers.
  */
-export enum AccountProvider {
-  /**
-   * Google Mail (Gmail) account provider.
-   */
-  GMAIL = 'GMAIL',
+export interface AccountType {
+  type: 'Email' | 'Retailer',
+  name: string,
+  icon?: string,
+  key: string
 }
 
-/**
- * A reverse lookup map to locate the {@link AccountProvider} by string value.
- */
-export const providers: Map<string, AccountProvider> = new Map(
-  Object.values(AccountProvider).map((value) => [`${value}`, value] as const),
-);
+// /**
+//  * A reverse lookup map to locate the {@link AccountProvider} by string value.
+//  */
+// export const providers: Map<string, AccountProvider> = new Map(
+//   Object.values(AccountProvider).map((value) => [`${value}`, value] as const),
+// );

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@
  */
 import { registerPlugin } from '@capacitor/core';
 
-import { AccountProvider } from './account';
 import type { Account } from './account';
 import type { AdditionalLine } from './additional-line';
 import type { Coupon } from './coupon';
@@ -41,7 +40,7 @@ const plugin: ReceiptCapturePlugin = registerPlugin<ReceiptCapturePlugin>('Recei
  */
 const instance: ReceiptCapture = new ReceiptCapture(plugin);
 
-export { instance, AccountProvider };
+export { instance };
 export type {
   AdditionalLine,
   Coupon,

--- a/src/receipt-capture-plugin.ts
+++ b/src/receipt-capture-plugin.ts
@@ -3,6 +3,7 @@
  * MIT license. See LICENSE file in root directory.
  */
 
+import { Account } from './account';
 import type { Receipt } from './receipt';
 
 export interface ReceiptCapturePlugin {
@@ -34,15 +35,11 @@ export interface ReceiptCapturePlugin {
     username: string;
     password: string;
     provider: string;
-  }): Promise<{ username: string; provider: string; isVerified: boolean }>;
+  }): Promise<Account>;
 
-  retailers(): Promise<{ accounts: [{ username: string; provider: string; isVerified: boolean }] }>;
+  retailers(): Promise<Account[]>;
 
-  removeRetailer(options: { username: string; provider: string }): Promise<{
-    username: string;
-    provider: string;
-    isVerified: boolean;
-  }>;
+  removeRetailer(options: { username: string; provider: string }): Promise<Account>;
 
   orders(): Promise<{
     provider: string;

--- a/src/receipt-capture-plugin.ts
+++ b/src/receipt-capture-plugin.ts
@@ -14,6 +14,8 @@ export interface ReceiptCapturePlugin {
 
   scan(): Promise<Receipt>;
 
+  accounts(): Promise<Account[]>;
+
   loginWithEmail(options: {
     username: string;
     password: string;
@@ -25,10 +27,6 @@ export interface ReceiptCapturePlugin {
     scans: Receipt[];
   }>;
 
-  verifyEmail(): Promise<{
-    accounts: { username: string; provider: string; verified: boolean }[];
-  }>;
-
   removeEmail(options: { username: string; password: string; provider: string }): Promise<{ success: boolean }>;
 
   loginWithRetailer(options: {
@@ -36,8 +34,6 @@ export interface ReceiptCapturePlugin {
     password: string;
     provider: string;
   }): Promise<Account>;
-
-  retailers(): Promise<Account[]>;
 
   removeRetailer(options: { username: string; provider: string }): Promise<Account>;
 

--- a/src/receipt-capture-web.ts
+++ b/src/receipt-capture-web.ts
@@ -18,9 +18,6 @@ export class ReceiptCaptureWeb extends WebPlugin implements ReceiptCapturePlugin
   }): Promise<Account> {
     throw new Error('Method not implemented.');
   }
-  retailers(): Promise<Account[]> {
-    throw new Error('Method not implemented.');
-  }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   removeRetailer(_options: {
     username: string;
@@ -40,6 +37,10 @@ export class ReceiptCaptureWeb extends WebPlugin implements ReceiptCapturePlugin
     throw this.unimplemented('Mobile Only.');
   }
 
+  async accounts(): Promise<Account[]>{
+    throw this.unimplemented('Mobile Only.');
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   loginWithEmail(_options: {
     username: string;
@@ -52,12 +53,6 @@ export class ReceiptCaptureWeb extends WebPlugin implements ReceiptCapturePlugin
   scrapeEmail(): Promise<{
     login: { username: string; provider: string };
     scans: Receipt[];
-  }> {
-    throw this.unimplemented('Mobile Only.');
-  }
-
-  verifyEmail(): Promise<{
-    accounts: { username: string; provider: string; verified: boolean }[];
   }> {
     throw this.unimplemented('Mobile Only.');
   }

--- a/src/receipt-capture-web.ts
+++ b/src/receipt-capture-web.ts
@@ -7,6 +7,7 @@ import { WebPlugin } from '@capacitor/core';
 
 import type { Receipt } from './receipt';
 import type { ReceiptCapturePlugin } from './receipt-capture-plugin';
+import { Account } from './account';
 
 export class ReceiptCaptureWeb extends WebPlugin implements ReceiptCapturePlugin {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -14,17 +15,17 @@ export class ReceiptCaptureWeb extends WebPlugin implements ReceiptCapturePlugin
     username: string;
     password: string;
     provider: string;
-  }): Promise<{ username: string; provider: string; isVerified: boolean }> {
+  }): Promise<Account> {
     throw new Error('Method not implemented.');
   }
-  retailers(): Promise<{ accounts: [{ username: string; provider: string; isVerified: boolean }] }> {
+  retailers(): Promise<Account[]> {
     throw new Error('Method not implemented.');
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   removeRetailer(_options: {
     username: string;
     provider: string;
-  }): Promise<{ username: string; provider: string; isVerified: boolean }> {
+  }): Promise<Account> {
     throw new Error('Method not implemented.');
   }
   orders(): Promise<{ provider: string; username: string; scan: Receipt }> {

--- a/src/receipt-capture.ts
+++ b/src/receipt-capture.ts
@@ -3,8 +3,7 @@
  * MIT license. See LICENSE file in root directory.
  */
 
-import type { Account, AccountProvider } from './account';
-import { providers } from './account';
+import type { Account } from './account';
 import type { Receipt } from './receipt';
 import type { ReceiptCapturePlugin } from './receipt-capture-plugin';
 
@@ -52,15 +51,21 @@ export class ReceiptCapture {
    * @param provider - The {@link AccountProvider}.
    * @returns A Promise that resolves to the logged-in Account object.
    */
-  loginWithEmail = async (username: string, password: string, provider: AccountProvider): Promise<Account> => {
+  loginWithEmail = async (username: string, password: string, provider: string): Promise<Account> => {
     const rsp = await this.plugin.loginWithEmail({
       username: username,
       password: password,
-      provider: provider.valueOf(),
+      provider: provider,
     });
     return {
       username: rsp.username,
-      provider: providers.get(rsp.provider),
+      accountType: {
+        type: 'Email',
+        name: provider,
+        icon: undefined,
+        key: provider
+      }
+      //provider: providers.get(rsp.provider),
     };
   };
 
@@ -75,7 +80,12 @@ export class ReceiptCapture {
       callback(
         {
           username: rsp.login.username,
-          provider: providers.get(rsp.login.provider),
+          accountType: {
+            type: 'Email',
+            name: rsp.login.provider,
+            icon: undefined,
+            key: rsp.login.provider
+          }
         },
         rsp.scans,
       );
@@ -89,11 +99,11 @@ export class ReceiptCapture {
    * @returns A Promise that resolves when the account is removed.
    * @throws Error if removal fails.
    */
-  removeEmail = async (username: string, password: string, provider: AccountProvider): Promise<void> => {
+  removeEmail = async (username: string, password: string, provider: string): Promise<void> => {
     const rsp = await this.plugin.removeEmail({
       username: username,
       password: password,
-      provider: provider.valueOf(),
+      provider: provider,
     });
     if (!rsp.success) throw Error(`Failed to remove: ${provider} | ${username}`);
   };
@@ -108,12 +118,17 @@ export class ReceiptCapture {
       return {
         username: acc.username,
         verified: acc.verified,
-        provider: providers.get(acc.provider),
+        accountType: {
+          type: 'Email',
+          name: acc.provider,
+          icon: undefined,
+          key: acc.provider
+        }
       };
     });
   };
 
-  loginWithRetailer = async (username: string, password: string, provider: string): Promise<RetailerAccount> => {
+  loginWithRetailer = async (username: string, password: string, provider: string): Promise<Account> => {
     return this.plugin.loginWithRetailer({
       username,
       password,
@@ -121,12 +136,12 @@ export class ReceiptCapture {
     });
   };
 
-  retailers = async (): Promise<RetailerAccount[]> => {
-    return (await this.plugin.retailers()).accounts;
+  retailers = async (): Promise<Account[]> => {
+    return (await this.plugin.retailers());
   };
 
-  removeRetailer = async (username: string, provider: string): Promise<RetailerAccount> => {
-    return await this.plugin.removeRetailer({ username, provider });
+  removeRetailer = async (username: string, provider: string): Promise<Account> => {
+    return await this.plugin.removeRetailer({username, provider});
   };
 
   orders = async (): Promise<{
@@ -141,8 +156,4 @@ export class ReceiptCapture {
   flushRetailer = async (): Promise<void> => this.plugin.flushRetailer();
 }
 
-interface RetailerAccount {
-  username: string;
-  provider: string;
-  isVerified: boolean;
-}
+

--- a/src/receipt-capture.ts
+++ b/src/receipt-capture.ts
@@ -108,26 +108,6 @@ export class ReceiptCapture {
     if (!rsp.success) throw Error(`Failed to remove: ${provider} | ${username}`);
   };
 
-  /**
-   * Load and verify all locally cached email accounts.
-   * @returns A Promise that resolves to an array of Accounts.
-   */
-  verifyEmail = async (): Promise<Account[]> => {
-    const rsp = await this.plugin.verifyEmail();
-    return rsp.accounts.map((acc) => {
-      return {
-        username: acc.username,
-        verified: acc.verified,
-        accountType: {
-          type: 'Email',
-          name: acc.provider,
-          icon: undefined,
-          key: acc.provider
-        }
-      };
-    });
-  };
-
   loginWithRetailer = async (username: string, password: string, provider: string): Promise<Account> => {
     return this.plugin.loginWithRetailer({
       username,
@@ -136,9 +116,9 @@ export class ReceiptCapture {
     });
   };
 
-  retailers = async (): Promise<Account[]> => {
-    return (await this.plugin.retailers());
-  };
+  accounts = async (): Promise<Account[]> =>{
+    return (await this.plugin.accounts())
+  }
 
   removeRetailer = async (username: string, provider: string): Promise<Account> => {
     return await this.plugin.removeRetailer({username, provider});


### PR DESCRIPTION
Changed the calls of the plugin, now the verifyEmail and the retailers requests turned into accounts, that will return all accounts to the receipt-capacitor
